### PR TITLE
Added example call to IoTHubClient_LL_SendReportedState()

### DIFF
--- a/app/iothubClient.ino
+++ b/app/iothubClient.ino
@@ -159,3 +159,9 @@ void twinCallback(
     parseTwinMessage(temp);
     free(temp);
 }
+
+static void reportedStateCallback(int status_code, void* userContextCallback)
+{
+  (void)userContextCallback;
+  printf("Device Twin reported properties update completed with result: %d\r\n", status_code);
+}

--- a/app/message.ino
+++ b/app/message.ino
@@ -85,12 +85,26 @@ void parseTwinMessage(char *message)
         return;
     }
 
+    //Create object for Device Twin response
+    JsonObject& response = jsonBuffer.createObject();
+
     if (root["desired"]["interval"].success())
     {
         interval = root["desired"]["interval"];
+        response["interval"] = interval;
     }
     else if (root.containsKey("interval"))
     {
         interval = root["interval"];
+        response["interval"] = interval;
     }
+
+    // return device state
+    String returnMessage;
+    response.printTo(returnMessage);
+  
+    const char* reportedState = returnMessage.c_str();
+    size_t reportedStateSize = strlen(reportedState);
+    
+    IoTHubClient_LL_SendReportedState(iotHubClientHandle, (const unsigned char*)reportedState, reportedStateSize, reportedStateCallback, iotHubClientHandle);
 }


### PR DESCRIPTION
Added a sample call to IoTHubClient_LL_SendReportedState() which reports updated device twin properties to IoT hub. This implementation was found on [the azure-iot-sdk-c project](/Azure/azure-iot-sdk-c/blob/master/iothub_client/samples/iothub_client_sample_device_twin/iothub_client_sample_device_twin.cl). I have improved the same by using the arduinoJson library to compose the response message. 